### PR TITLE
Appveyor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   # build nix library
   - mkdir nix-build
   - cd nix-build
-  - git clone https://github.com/G-Node/nix
+  - git clone https://github.com/G-Node/nix --branch=1.3
   - cd nix
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   - PLATFORM: x64
     CONFIGURATION: Release
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    RDP: "no"
 
   # 32 bit
   - PLATFORM: x86
@@ -17,8 +18,8 @@ environment:
 install:
 
   # Install Maven
-  - set PATH=%PATH%;C:\bin\apache-maven-3.6\bin
-  - set MVN_VERSION=3.6
+  - set MVN_VERSION=3.6.0
+  - set PATH=%PATH%;C:\bin\apache-maven-%MVN_VERSION%\bin
   - if not exist "C:\bin\apache-maven-%MVN_VERSION%\bin\*.*" (echo Maven %MVN_VERSION% not installed, so install it & cinst maven -Version %MVN_VERSION%) else (echo  Maven %MVN_VERSION% already installed)
 
 
@@ -58,5 +59,12 @@ on_failure:
 test_script: []
 
 cache:
-  - C:\bin\apache-maven-3.6
+  - C:\bin\apache-maven-3.6.0
   - C:\Users\appveyor\.m2
+
+
+on_finish:
+  - ps: |
+      if ($env:RDP -eq "yes") {
+          $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+      }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,12 @@ environment:
 
 install:
 
+  # Install Maven
+  - set PATH=%PATH%;C:\bin\apache-maven-3.6\bin
+  - set MVN_VERSION=3.6
+  - if not exist "C:\bin\apache-maven-%MVN_VERSION%\bin\*.*" (echo Maven %MVN_VERSION% not installed, so install it & cinst maven -Version %MVN_VERSION%) else (echo  Maven %MVN_VERSION% already installed)
+
+
   # Set VC variables for the platform
   - if %PLATFORM% == x64 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
   - if %PLATFORM% == x86 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat"
@@ -38,11 +44,6 @@ install:
   - cmake --build . --config %CONFIGURATION%
   - cd ..
   - cd ..
-
-  # Install Maven
-  - set PATH=%PATH%;C:\bin\apache-maven-3.6\bin
-  - set MVN_VERSION=3.6
-  - if not exist "C:\bin\apache-maven-%MVN_VERSION%\bin\*.*" (echo Maven %MVN_VERSION% not installed, so install it & cinst maven -Version %MVN_VERSION%) else (echo  Maven %MVN_VERSION% already installed)
 
 build_script:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - c:\deps\nixenv.bat
 
   # Build NIX
-  - git clone https://github.com/G-Node/nix.git
+  - git clone https://github.com/G-Node/nix.git --branch=1.3
   - cd nix
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,9 +40,9 @@ install:
   - cd ..
 
   # Install Maven
-  - set PATH=%PATH%;C:\bin\apache-maven-3.2.5\bin
-  - set MVN_VERSION=3.2.5
-  - if not exist "C:\bin\apache-maven-%MVN_VERSION%\bin\*.*" (echo Maven %MVN_VERSION% not installed, so install it & cinst maven --version %MVN_VERSION% --allow-empty-checksums) else (echo  Maven %MVN_VERSION% already installed)
+  - set PATH=%PATH%;C:\bin\apache-maven-3.6\bin
+  - set MVN_VERSION=3.6
+  - if not exist "C:\bin\apache-maven-%MVN_VERSION%\bin\*.*" (echo Maven %MVN_VERSION% not installed, so install it & cinst maven -Version %MVN_VERSION%) else (echo  Maven %MVN_VERSION% already installed)
 
 build_script:
 
@@ -57,5 +57,5 @@ on_failure:
 test_script: []
 
 cache:
-  - C:\bin\apache-maven-3.2.5
+  - C:\bin\apache-maven-3.6
   - C:\Users\appveyor\.m2


### PR DESCRIPTION
- Install Maven 3.6.0: Older Maven version fails to install through Chocolatey.
- Clone NIX version 1.3: Current bindings don't build against 1.4. Specifying 1.3 until we bring them up to date.
- Add RDP option: For troubleshooting, we can now change the RDP env var to "yes" to enable remote desktop on the build machine when a build finishes.